### PR TITLE
[FIX] PostgreSQL Error: could not obtain lock on row in relation “ir_cron"

### DIFF
--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -285,7 +285,7 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                             pop_server.quit()
                         except OSError:
                             _logger.warning('Failed to properly finish pop connection: %s.', server.name, exc_info=True)
-            server.write({'date': fields.Datetime.now()})
+            server.with_context(additionnal_context).write({'date': fields.Datetime.now()})
         return True
 
     def _get_connection_type(self):


### PR DESCRIPTION
Explanation can be found in the following blog article:

https://elementure.nl/en/odoo/unraveling-the-postgresql-error-could-not-obtain-lock-on-row-in-relation-ir_cron

Description of the issue/feature this PR addresses: Resolves the PostgreSQL error: Could not obtain lock on row in relation "ir_cron"

Current behavior before PR: The function fetch_mail tries to update a locked record. (The blog article referred to in the commit proves this.)

Desired behavior after PR is merged: The PostgreSQL error no longer occurs.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
